### PR TITLE
Fix/widgets display (codbex/codbex-olympus#236)

### DIFF
--- a/codbex-products/widgets/inventory-accuracy/index.html
+++ b/codbex-products/widgets/inventory-accuracy/index.html
@@ -43,20 +43,24 @@
     </head>
 
     <body class="overflow-h">
-        <fd-panel expanded="true" class="fd-col fd-col--12">
-            <fd-panel-content aria-label="Products Content">
-
-                <div class="fd-row" style="margin: 0.5em">
-                    <div class="fd-col fd-col--6 fd-col-md--3 fd-col-lg--3 fd-col-xl--3">
-                        <div role="button" tabindex="0" class="inventory-tile tile-auto-layout">
-                            <div class="inventory-tile-title">Inventory Accuracy</div>
-                            <div class="inventory-tile-content">100%</div>
-                            <div class="inventory-tile-footer">Today: {{ today | date:'dd-MM-yyyy' }}</div>
+        <div role="button" tabindex="0" class="fd-tile fd-tile--feed tile-auto-layout"
+            ng-click="openPerspective('sales-orders')">
+            <div class="fd-tile__header tile-auto-layout">
+                <div class="fd-tile__title">Inventory Accuracy</div>
+            </div>
+            <div class="fd-tile__content tile-auto-layout">
+                <div class="fd-tile__section">
+                    <div class="fd-numeric-content">
+                        <div class="fd-numeric-content__kpi-container">
+                            <div class="fd-numeric-content__kpi">100%</div>
                         </div>
                     </div>
                 </div>
-            </fd-panel-content>
-        </fd-panel>
+            </div>
+            <div class="fd-tile__footer tile-auto-layout">
+                <span class="fd-tile__footer-text">Today: {{ today | date:'dd-MM-yyyy' }}</span>
+            </div>
+        </div>
 
     </body>
 

--- a/codbex-products/widgets/inventory-accuracy/index.html
+++ b/codbex-products/widgets/inventory-accuracy/index.html
@@ -44,7 +44,7 @@
 
     <body class="overflow-h">
         <div role="button" tabindex="0" class="fd-tile fd-tile--feed tile-auto-layout"
-            ng-click="openPerspective('sales-orders')">
+            ng-click="openPerspective('inventory-accuracy')">
             <div class="fd-tile__header tile-auto-layout">
                 <div class="fd-tile__title">Inventory Accuracy</div>
             </div>

--- a/codbex-products/widgets/product-details/index.html
+++ b/codbex-products/widgets/product-details/index.html
@@ -18,10 +18,10 @@
 
         <style>
             .tile-auto-layout {
-                min-height: auto;
-                height: auto;
-                width: auto;
                 max-width: 99%;
+                min-height: 335px;
+                max-height: 335px;
+                height: 335px;
                 margin: 1px;
             }
 
@@ -42,48 +42,39 @@
     </head>
 
     <body class="overflow-h">
-        <fd-panel expanded="true" class="fd-col fd-col--12">
-
-            <fd-panel-content aria-label="Products Content">
-
-                <div class="fd-row" style="margin: 0.5em">
-                    <fd-card card-type="table">
-                        <fd-card-header ng-click="openPerspective('products')">
-                            <fd-card-title>Product Details</fd-card-title>
-                        </fd-card-header>
-                        <fd-card-content>
-                            <table fd-table inner-borders="horizontal" outer-borders="none" style="min-height:12.5rem">
-                                <tbody fd-table-body>
-                                    <tr fd-table-row>
-                                        <td fd-table-cell class="fd-padding--none" width="50%">
-                                            <fd-list>
-                                                <fd-list-item>
-                                                    <div class="dg-hbox dg-full-width">
-                                                        <span style="flex:1">Product Categories</span>
-                                                        <span>{{ProductData.ActiveCategories}}</span>
-                                                    </div>
-                                                </fd-list-item>
-                                                <fd-list-item class="dg-no-border-bottom">
-                                                    <div class="dg-hbox dg-full-width">
-                                                        <span style="flex:1">All Products</span>
-                                                        <span>{{ProductData.AllProducts}}</span>
-                                                    </div>
-                                                </fd-list-item>
-                                            </fd-list>
-                                        </td>
-                                        <td fd-table-cell width="50%">
-                                            <!-- Right section for doughnut chart -->
-                                            <canvas id="doughnutChart" width="200" height="200"></canvas>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </fd-card-content>
-                    </fd-card>
-                </div>
-            </fd-panel-content>
-        </fd-panel>
-
+        <fd-card class="tile-auto-layout" card-type="table">
+            <fd-card-header ng-click="openPerspective('products')">
+                <fd-card-title>Product Details</fd-card-title>
+            </fd-card-header>
+            <fd-card-content>
+                <table fd-table inner-borders="horizontal" outer-borders="none" style="min-height:12.5rem">
+                    <tbody fd-table-body>
+                        <tr fd-table-row>
+                            <td fd-table-cell class="fd-padding--none" width="50%">
+                                <fd-list>
+                                    <fd-list-item>
+                                        <div class="dg-hbox dg-full-width">
+                                            <span style="flex:1">Product Categories</span>
+                                            <span>{{ProductData.ActiveCategories}}</span>
+                                        </div>
+                                    </fd-list-item>
+                                    <fd-list-item class="dg-no-border-bottom">
+                                        <div class="dg-hbox dg-full-width">
+                                            <span style="flex:1">All Products</span>
+                                            <span>{{ProductData.AllProducts}}</span>
+                                        </div>
+                                    </fd-list-item>
+                                </fd-list>
+                            </td>
+                            <td fd-table-cell width="50%">
+                                <!-- Right section for doughnut chart -->
+                                <canvas id="doughnutChart" width="200" height="200"></canvas>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </fd-card-content>
+        </fd-card>
     </body>
 
 </html>

--- a/codbex-products/widgets/top-products/index.html
+++ b/codbex-products/widgets/top-products/index.html
@@ -18,10 +18,10 @@
 
         <style>
             .tile-auto-layout {
-                min-height: auto;
-                height: auto;
-                width: auto;
                 max-width: 99%;
+                min-height: 335px;
+                max-height: 335px;
+                height: 335px;
                 margin: 1px;
             }
 
@@ -42,46 +42,38 @@
     </head>
 
     <body class="overflow-h">
-        <fd-panel expanded="true" class="fd-col fd-col--12">
+        <fd-card class="tile-auto-layout" card-type="table">
+            <fd-card-header ng-click="openPerspective('products')">
+                <fd-card-title>Top Products</fd-card-title>
+            </fd-card-header>
+            <fd-card-content>
+                <table class="fd-table fd-table--no-horizontal-borders fd-table--no-vertical-borders">
+                    <thead class="fd-table__header">
+                        <tr class="fd-table__row">
+                            <th class="fd-table__cell">Product</th>
+                            <th class="fd-table__cell">
+                                <button class="fd-button fd-button--compact" ng-click="displayByUnits()">By
+                                    Units</button>
+                            </th>
+                            <th class="fd-table__cell">
+                                <button class="fd-button fd-button--compact" ng-click="displayByRevenue()">By
+                                    Revenue</button>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody class="fd-table__body" id="top_products">
+                        <tr ng-repeat="next in displayedProducts">
+                            <td class="fd-table__cell">
+                                <a class="fd-link"><span class="fd-link__content">{{next.productName}}</span></a>
+                            </td>
+                            <td class="fd-table__cell">{{next.unitCount}}</td>
+                            <td class="fd-table__cell">{{next.revenue}}</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </fd-card-content>
+        </fd-card>
 
-            <fd-panel-content aria-label="Products Content">
-
-                <div class="fd-row" style="margin: 0.5em">
-                    <fd-card card-type="table">
-                        <fd-card-header ng-click="openPerspective('products')">
-                            <fd-card-title>Top Products</fd-card-title>
-                        </fd-card-header>
-                        <fd-card-content>
-                            <table class="fd-table fd-table--no-horizontal-borders fd-table--no-vertical-borders">
-                                <thead class="fd-table__header">
-                                    <tr class="fd-table__row">
-                                        <th class="fd-table__cell">Product</th>
-                                        <th class="fd-table__cell">
-                                            <button class="fd-button fd-button--compact" ng-click="displayByUnits()">By
-                                                Units</button>
-                                        </th>
-                                        <th class="fd-table__cell">
-                                            <button class="fd-button fd-button--compact"
-                                                ng-click="displayByRevenue()">By Revenue</button>
-                                        </th>
-                                    </tr>
-                                </thead>
-                                <tbody class="fd-table__body" id="top_products">
-                                    <tr ng-repeat="next in displayedProducts">
-                                        <td class="fd-table__cell">
-                                            <a class="fd-link"><span
-                                                    class="fd-link__content">{{next.productName}}</span></a>
-                                        </td>
-                                        <td class="fd-table__cell">{{next.unitCount}}</td>
-                                        <td class="fd-table__cell">{{next.revenue}}</td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </fd-card-content>
-                    </fd-card>
-                </div>
-            </fd-panel-content>
-        </fd-panel>
     </body>
 
 </html>


### PR DESCRIPTION
remade widgets to display properly
BEFORE:
![image](https://github.com/user-attachments/assets/32443c18-a9fe-4329-af50-915126afac24)
AFTER:
![image](https://github.com/user-attachments/assets/c8e77f7b-1fd8-4d6d-b7c0-48bc2ace91ab)

BEFORE:
![image](https://github.com/user-attachments/assets/7a1461d7-39e3-42ea-9a92-065422971247)
AFTER:
![image](https://github.com/user-attachments/assets/77e06e36-2771-460d-a2f3-2c2ed0062d07)

BEFORE:
![image](https://github.com/user-attachments/assets/21a97758-3515-402c-869c-342a50a7b699)
AFTER:
![image](https://github.com/user-attachments/assets/24f3e033-7358-4c34-82b9-a97c52b0479e)
